### PR TITLE
Do no release to Prod on Broad Holidays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,17 +34,29 @@ jobs:
       - deploy:
           name: Deploy
           command: |
+
+            CURRYEAR="$(date +%Y)"
+            CURRDATE="$(date +%m/%d/%Y)"
+
+            # Holiday dates specifc to 2021 that will need to be updated next year
+            HOLIDAYS=("03/12/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
+            "09/06/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021")
+
+            # List of Holidays the Broad is closed for every year
+            HOLIDAYSEACHYEAR=("01/01" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")
+
+            for val in "${HOLIDAYSEACHYEAR[@]}"; do
+               HOLIDAYS+=("${val}/${CURRYEAR}")
+            done
+
             # Do not release on Broad Holidays
-            CURRDATE=$(date +%m/%d/%Y)
-             array=("03/12/2021" "4/19/2021" "5/28/2021" "5/31/2021" "7/2/2021" "7/5/2021"
-             "9/6/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021" "12/24/2021"
-              "12/27/2021" "12/28/2021" "12/29/2021" "12/30/2021" "12/30/2021")
-            for val in "${array[@]}"; do
+            for val in "${HOLIDAYS[@]}"; do
                  if [ ${val} = "${CURRDATE}" ]; then
                     echo Holiday - no release
                     circleci-agent step halt
                  fi
             done
+
             if [[ "$PREVENT_DEPLOY" = true ]]; then
               echo PREVENT_DEPLOY is enabled - no release
               circleci-agent step halt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,19 @@ jobs:
       - deploy:
           name: Deploy
           command: |
+            # Do not release on Broad Holidays
+            CURRDATE=$(date +%m/%d/%Y)
+             array=("03/12/2021" "4/19/2021" "5/28/2021" "5/31/2021" "7/2/2021" "7/5/2021"
+             "9/6/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021" "12/24/2021"
+              "12/27/2021" "12/28/2021" "12/29/2021" "12/30/2021" "12/30/2021")
+            for val in "${array[@]}"; do
+                 if [ ${val} = "${CURRDATE}" ]; then
+                    echo Holiday - no release
+                    circleci-agent step halt
+                 fi
+            done
             if [[ "$PREVENT_DEPLOY" = true ]]; then
+              echo PREVENT_DEPLOY is enabled - no release
               circleci-agent step halt
             else
               set -o nounset

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
 
             # Do not release on Broad Holidays
             for val in "${HOLIDAYS[@]}"; do
-                 if [ ${val} = "${CURRDATE}" ]; then
+                 if [ "${val}" = "${CURRDATE}" ]; then
                     echo Holiday - no release
                     circleci-agent step halt
                  fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             CURRYEAR="$(date +%Y)"
             CURRDATE="$(date +%m/%d/%Y)"
 
-            # Holiday dates specifc to 2021 that will need to be updated next year
+            # Holiday dates specific to 2021 that will need to be updated next year
             HOLIDAYS=("03/12/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
             "09/06/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021")
 


### PR DESCRIPTION
Update the circleci config so to not release the UI to prod on Broad Holidays.

This PR will make the change for the remaining 2021 Holidays, and will automatically recognize the end-of-year closing that occurs yearly.

My plan is to make a reminder (probably in slack) to update the year specific holidates 

Tested running through a YAML validator and running the script in bash terminal