### PR TITLE
Fix Holiday check bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             CURRDATE="$(date +%m/%d/%Y)"
 
             # Holiday dates specific to 2021 that will need to be updated next year
-            HOLIDAYS=("03/12/2021" "03/17/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
+            HOLIDAYS=("03/12/2021" "03/18/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
             "09/06/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021")
 
             # List of Holidays the Broad is closed for every year

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             CURRDATE="$(date +%m/%d/%Y)"
 
             # Holiday dates specific to 2021 that will need to be updated next year
-            HOLIDAYS=("03/12/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
+            HOLIDAYS=("03/12/2021" "03/17/2021" "04/19/2021" "05/28/2021" "05/31/2021" "07/02/2021" "07/05/2021"
             "09/06/2021" "10/11/2021" "11/11/2021" "11/25/2021" "11/26/2021" "12/23/2021")
 
             # List of Holidays the Broad is closed for every year
@@ -54,6 +54,7 @@ jobs:
                  if [ "${val}" = "${CURRDATE}" ]; then
                     echo Holiday - no release
                     circleci-agent step halt
+                    exit 0
                  fi
             done
 


### PR DESCRIPTION
Exit upon finding the Holiday.

The "don't-deploy-on-holidays" code detected the holiday last Friday correctly, however it did not fully exit (my misunderstanding of what "circleci-agent step halt" ought to do) and so still released. This change will cause the job to fully exit once a Holiday has been detected.

Also I added today's date to the holiday list so I can manually test this change. Will need to make a PR to revert that once I can confirm it works.