### PR TITLE
Update version of Node used in find-build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:14
+      - image: cimg/node:16.14
         user: node
   gcloud:
     docker:


### PR DESCRIPTION
Last week, the [deploy job failed](https://app.circleci.com/pipelines/github/DataBiosphere/saturn-ui-prod-deploy/696/workflows/e4e6f5cc-2ebe-4428-8a7f-9deb13962748/jobs/2344) with an error: `curl: no URL specified!`. However, the underlying cause was an error in the [find-build job](https://app.circleci.com/pipelines/github/DataBiosphere/saturn-ui-prod-deploy/696/workflows/e4e6f5cc-2ebe-4428-8a7f-9deb13962748/jobs/2343) that gets a URL from CircleCI.

`yarn find-build` calls an async function to get the build URL.
https://github.com/DataBiosphere/saturn-ui-prod-deploy/blob/ef7593198f3ff451d2d7a9fa1efc7eeee5fc8d07/src/find-build.js#L6-L17

Any errors that occur in that function become unhandled promise rejections. Prior to Node 15, Node's default behavior for unhandled rejections was to print a warning.
- https://nodejs.org/en/blog/release/v15.0.0/#throw-on-unhandled-rejections-33021
- https://nodejs.org/docs/latest-v14.x/api/cli.html#cli_unhandled_rejections_mode

Thus, despite the error, `yarn find-build` exited successfully and the `find-build` job was marked successful.

This updates the `find-build` job to run on Node 16, where unhandled rejections would be thrown as errors and cause `yarn find-build` to exit with an error code. This is also the same version of Node that terra-ui `build` jobs run on (https://github.com/DataBiosphere/terra-ui/blob/ddd25ee28a5eb85062982be7f08e6d9c6c4c6e64/.circleci/config.yml#L10).