### PR TITLE
Remove user from node executor configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ executors:
   node:
     docker:
       - image: cimg/node:16.14
-        user: node
   gcloud:
     docker:
       - image: google/cloud-sdk:alpine


### PR DESCRIPTION
It looks like #22 solved one problem but created another. On the last run, the `find-build` job failed because the Docker image had no user `node`. It looks like CircleCI's images use a `circleci` user.

https://app.circleci.com/pipelines/github/DataBiosphere/saturn-ui-prod-deploy/705/workflows/9db493f5-9ab2-4f06-8889-14d61a2d3d3d/jobs/2356/steps