### PR TITLE
Add Slack notification for failures in the find-build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,12 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: [ artifact-url ]
+      - slack/status:
+          channel: "C6DTFUCDD" # workbench-release
+          include_job_number_field: false
+          include_project_field: false
+          fail_only: true
+          failure_message: ":sadpanda: $CIRCLE_JOB failed."
   deploy:
     executor: gcloud
     steps:


### PR DESCRIPTION
Currently, we only have Slack notifications for the `deploy` job. If the `find-build` job fails, no notification is sent.

This copies the `slack/status` step from `deploy` to `find-build`, with a few changes: `fail_only` is set to true to avoid getting two notifications for successful deploys and the `success_message` configuration is removed.

Docs for the Slack Orb at https://github.com/CircleCI-Public/slack-orb/tree/v3.4.2