### PR TITLE
Update holiday dates for 2022

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             "09/02/2022" "09/05/2022" "10/10/2022" "11/11/2022" "11/24/2022" "11/25/2022" "12/23/2022")
 
             # List of Holidays the Broad is closed for every year
-            HOLIDAYSEACHYEAR=("01/01" "06/19" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")
+            HOLIDAYSEACHYEAR=("01/01" "06/19" "07/04" "11/11" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")
 
             for val in "${HOLIDAYSEACHYEAR[@]}"; do
                HOLIDAYS+=("${val}/${CURRYEAR}")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,11 @@ jobs:
             # Holiday dates specific to 2022 that will need to be updated next year
             # as per https://intranet.broadinstitute.org/keywords/holiday-calendar
             # and https://intranet.broadinstitute.org/hr/human-resources-policy-manual/time
-            HOLIDAYS=("12/23/2021" "01/17/2022" "02/21/2022" "04/18/2022" "05/30/2022" "07/01/2022" "07/04/2022"
+            HOLIDAYS=("12/23/2021" "01/17/2022" "02/21/2022" "04/18/2022" "05/30/2022" "06/20/2022" "07/01/2022" "07/04/2022"
             "09/02/2022" "09/05/2022" "10/10/2022" "11/11/2022" "11/24/2022" "11/25/2022" "12/23/2022")
 
             # List of Holidays the Broad is closed for every year
-            HOLIDAYSEACHYEAR=("01/01" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")
+            HOLIDAYSEACHYEAR=("01/01" "06/19" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")
 
             for val in "${HOLIDAYSEACHYEAR[@]}"; do
                HOLIDAYS+=("${val}/${CURRYEAR}")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ jobs:
             # Holiday dates specific to 2022 that will need to be updated next year
             # as per https://intranet.broadinstitute.org/keywords/holiday-calendar
             # and https://intranet.broadinstitute.org/hr/human-resources-policy-manual/time
-            HOLIDAYS=("12/23/2021" "01/17/2022" "02/21/2022" "04/18/2022" "05/30/2022" "07/04/2022"
-            "09/05/2022" "10/10/2022" "11/11/2022" "11/24/2022" "11/25/2022" "12/23/2022")
+            HOLIDAYS=("12/23/2021" "01/17/2022" "02/21/2022" "04/18/2022" "05/30/2022" "07/01/2022" "07/04/2022"
+            "09/02/2022" "09/05/2022" "10/10/2022" "11/11/2022" "11/24/2022" "11/25/2022" "12/23/2022")
 
             # List of Holidays the Broad is closed for every year
             HOLIDAYSEACHYEAR=("01/01" "12/24" "12/25" "12/26" "12/27" "12/28" "12/29" "12/30" "12/31")


### PR DESCRIPTION
I noticed that [a scheduled deploy ran last Friday](https://broadinstitute.slack.com/archives/C6DTFUCDD/p1653664268230039) despite it being a holiday. It turns out the holiday list is missing the additional holidays.
https://intranet.broadinstitute.org/hr/human-resources-policy-manual/time


