### PR TITLE
Output deployed revision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,15 @@ jobs:
       - checkout
       - run:
           name: Find build artifact
-          command: "yarn find-build > artifact-url"
+          command: |
+            yarn find-build > build-info
+            jq --raw-output .artifactUrl < build-info > artifact-url
+            jq --raw-output .revision < build-info > revision
       - persist_to_workspace:
           root: .
-          paths: [ artifact-url ]
+          paths:
+            - artifact-url
+            - revision
       - slack/status:
           channel: "C6DTFUCDD" # workbench-release
           include_job_number_field: false
@@ -73,6 +78,9 @@ jobs:
               gcloud auth activate-service-account --key-file=/tmp/sa-key.json
               gcloud app deploy --project=bvdp-saturn-prod --promote --quiet
             fi
+      - run:
+          name: Output revision
+          command: cat revision
       - slack/status:
           channel: "C6DTFUCDD" # workbench-release
           include_job_number_field: false

--- a/src/find-build.js
+++ b/src/find-build.js
@@ -7,11 +7,18 @@ const findBuild = async () => {
   const workflows = await fetch(`${base}/insights/${projectSlug}/workflows/build-deploy?branch=dev`).then(r => r.json()).then(o => o.items)
   const latestWorkflow = workflows.find(w => w.status === 'success')
 
+  const workflow = await fetch(`${base}/workflow/${latestWorkflow.id}`).then(r => r.json())
+  const pipeline = await fetch(`${base}/pipeline/${workflow.pipeline_id}`).then(r => r.json())
+  const revision = pipeline.vcs.revision
+
   const workflowJobs = await fetch(`${base}/workflow/${latestWorkflow.id}/job`).then(r => r.json()).then(o => o.items)
   const buildJob = workflowJobs.find(j => j.name === 'build' && j.status === 'success')
 
   const jobArtifacts = await fetch(`${base}/project/${projectSlug}/${buildJob.job_number}/artifacts`).then(r => r.json()).then(o => o.items)
-  console.log(jobArtifacts[0].url)
+  const artifactUrl = jobArtifacts[0].url
+
+  const buildInfo = { artifactUrl, revision }
+  console.log(JSON.stringify(buildInfo, null, 2))
 }
 
 findBuild()


### PR DESCRIPTION
As far as I can tell, our deployment automation currently provides no visibility into what was deployed. We have to guess at which revision was the last to pass tests before the scheduled deployment ran.

This updates...
- the `find-build.js` script to output the git revision along with the artifact URL
- the `find-build` job to store the git revision in a file (similar to how `artifact-url` is currently stored)
- the `deploy` job to output the git revision after a deployment

The `find-build` job uses [jq](https://stedolan.github.io/jq/) to split up the output of `find-build.js`. jq is one of the [tools pre-installed in the CircleCI images](https://circleci.com/docs/2.0/circleci-images/#pre-installed-tools).

For the `find-build.js` changes, more information about pipeline vs workflow vs job can be found in:
- https://circleci.com/blog/what-is-a-ci-cd-pipeline/
- https://circleci.com/docs/2.0/pipelines/