### PR TITLE
Fix path to revision file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             fi
       - run:
           name: Output revision
-          command: cat revision
+          command: cat /tmp/workspace/revision
       - slack/status:
           channel: "C6DTFUCDD" # workbench-release
           include_job_number_field: false


### PR DESCRIPTION
Follow up to #30.

Missed that the workspace directory persisted from the `find-build` step is not the working directory for the `deploy` step.