### PR TITLE
[TUIM-12] Replace deprecated deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - deploy:
+      - run:
           name: Deploy
           command: |
 


### PR DESCRIPTION
`deploy` steps are deprecated: https://circleci.com/docs/2.0/configuration-reference#deploy-deprecated