### PR TITLE
Select build artifact by path

### DIFF
--- a/src/find-build.js
+++ b/src/find-build.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch')
 
 const base = 'https://circleci.com/api/v2'
 const projectSlug = 'gh/DataBiosphere/terra-ui'
+const buildArtifactPath = 'build.tgz'
 
 const findBuild = async () => {
   const workflows = await fetch(`${base}/insights/${projectSlug}/workflows/build-deploy?branch=dev`).then(r => r.json()).then(o => o.items)
@@ -15,7 +16,8 @@ const findBuild = async () => {
   const buildJob = workflowJobs.find(j => j.name === 'build' && j.status === 'success')
 
   const jobArtifacts = await fetch(`${base}/project/${projectSlug}/${buildJob.job_number}/artifacts`).then(r => r.json()).then(o => o.items)
-  const artifactUrl = jobArtifacts[0].url
+  const buildArtifact = jobArtifacts.find(artifact => artifact.path === buildArtifactPath)
+  const artifactUrl = buildArtifact.url
 
   const buildInfo = { artifactUrl, revision }
   console.log(JSON.stringify(buildInfo, null, 2))


### PR DESCRIPTION
Currently, the find-bulld script assumes that the build bundle is the only artifact attached to the build job. This may break if we add more artifacts to the build job (such as in DataBiosphere/terra-ui#3304). This change selects the artifact containing the build bundle based on the artifact path.