### PR TITLE
[TUIM-28] Upgrade to Node v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:16.14
+      - image: cimg/node:18.10
   gcloud:
     docker:
       - image: google/cloud-sdk:alpine


### PR DESCRIPTION
Companion to https://github.com/DataBiosphere/terra-ui/pull/3435.

Node 18 is the current release and will become the active LTS release later this month.
https://github.com/nodejs/release#release-schedule

This switches CI jobs to use Node 18.

Tested by running `yarn find-build` locally using Node v18.10.0.