### PR TITLE
Retry CircleCI API requests

### DIFF
--- a/src/find-build.js
+++ b/src/find-build.js
@@ -4,18 +4,41 @@ const base = 'https://circleci.com/api/v2'
 const projectSlug = 'gh/DataBiosphere/terra-ui'
 const buildArtifactPath = 'build.tgz'
 
+const delay = t => new Promise(resolve => setTimeout(resolve, t * 1000))
+
+const fetchCircleCI = async (path, opts = {}) => {
+  const { maxRetries = 5 } = opts
+
+  let response = await fetch(`${base}/${path}`)
+  let nRequests = 1
+
+  while (!response.ok && nRequests < maxRetries) {
+    await delay(nRequests)
+    response = await fetch(`${base}/${path}`)
+    nRequests += 1
+  }
+
+  if (response.ok) {
+    const responseContent = await response.json()
+    return responseContent
+  } else {
+    const responseContent = await response.text()
+    throw new Error(`CircleCI request failed: ${responseContent}`)
+  }
+}
+
 const findBuild = async () => {
-  const workflows = await fetch(`${base}/insights/${projectSlug}/workflows/build-deploy?branch=dev`).then(r => r.json()).then(o => o.items)
+  const workflows = await fetchCircleCI(`insights/${projectSlug}/workflows/build-deploy?branch=dev`).then(o => o.items)
   const latestWorkflow = workflows.find(w => w.status === 'success')
 
-  const workflow = await fetch(`${base}/workflow/${latestWorkflow.id}`).then(r => r.json())
-  const pipeline = await fetch(`${base}/pipeline/${workflow.pipeline_id}`).then(r => r.json())
+  const workflow = await fetchCircleCI(`workflow/${latestWorkflow.id}`)
+  const pipeline = await fetchCircleCI(`pipeline/${workflow.pipeline_id}`)
   const revision = pipeline.vcs.revision
 
-  const workflowJobs = await fetch(`${base}/workflow/${latestWorkflow.id}/job`).then(r => r.json()).then(o => o.items)
+  const workflowJobs = await fetchCircleCI(`workflow/${latestWorkflow.id}/job`).then(o => o.items)
   const buildJob = workflowJobs.find(j => j.name === 'build' && j.status === 'success')
 
-  const jobArtifacts = await fetch(`${base}/project/${projectSlug}/${buildJob.job_number}/artifacts`).then(r => r.json()).then(o => o.items)
+  const jobArtifacts = await fetchCircleCI(`project/${projectSlug}/${buildJob.job_number}/artifacts`).then(o => o.items)
   const buildArtifact = jobArtifacts.find(artifact => artifact.path === buildArtifactPath)
   const artifactUrl = buildArtifact.url
 


### PR DESCRIPTION
Today's deploy failed in the find-build step.
https://app.circleci.com/pipelines/github/DataBiosphere/saturn-ui-prod-deploy/1028/workflows/b4f140ab-5fe7-4dea-8d05-ffdaf8b925fe/jobs/2991

On investigation, it looks like the [CircleCI job artifacts endpoint](https://circleci.com/docs/api/v2/index.html#operation/getJobArtifacts) is intermittently returning 400 responses. To work around this issue, this change adds retries to CircleCI API requests.