### PR TITLE
Set cookie for job artifacts request

### DIFF
--- a/src/find-build.js
+++ b/src/find-build.js
@@ -5,6 +5,11 @@ const projectSlug = 'gh/DataBiosphere/terra-ui'
 const buildArtifactPath = 'build.tgz'
 
 const findBuild = async () => {
+  // This request returns 401 but sets a cookie that we need for the job artifacts endpoint.
+  // Why only that endpoint needs the cookie is unknown.
+  const profileResponse = await fetch('https://circleci.com/api/v1.1/me')
+  const cookie = profileResponse.headers.raw()['set-cookie']
+
   const workflows = await fetch(`${base}/insights/${projectSlug}/workflows/build-deploy?branch=dev`).then(r => r.json()).then(o => o.items)
   const latestWorkflow = workflows.find(w => w.status === 'success')
 
@@ -15,7 +20,7 @@ const findBuild = async () => {
   const workflowJobs = await fetch(`${base}/workflow/${latestWorkflow.id}/job`).then(r => r.json()).then(o => o.items)
   const buildJob = workflowJobs.find(j => j.name === 'build' && j.status === 'success')
 
-  const jobArtifacts = await fetch(`${base}/project/${projectSlug}/${buildJob.job_number}/artifacts`).then(r => r.json()).then(o => o.items)
+  const jobArtifacts = await fetch(`${base}/project/${projectSlug}/${buildJob.job_number}/artifacts`, { headers: { cookie }}).then(r => r.json()).then(o => o.items)
   const buildArtifact = jobArtifacts.find(artifact => artifact.path === buildArtifactPath)
   const artifactUrl = buildArtifact.url
 


### PR DESCRIPTION
See thread https://broadinstitute.slack.com/archives/C01EHNUM73R/p1678983007290849.

The job artifacts endpoint has started returning 400 responses for find-build's requests. This appears to be related to CloudFront as the response headers include "x-cache: Error from cloudfront".

I found that the request worked in a browser that has visited the Terra UI CircleCI page, but not in a fresh incognito window. This suggested that the issue was related to cookies. If the job artifacts endpoint is passed the cookie returned from one of the other API endpoints, it returns successfully. Only the job artifacts endpoint seems to need this. Other API requests  in find-build respond ok.

Based on inspecting network requests on https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui, it seems like some but not all API endpoints return cookies. This adds a request to `https://circleci.com/api/v1.1/me` to get the cookie.