### PR TITLE
Update deploy schedule for the end of DST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
   deploy-prod:
     triggers:
       - schedule:
-          cron: "0 15 * * 1-5"
+          cron: "0 16 * * 1-5"
           filters:
             branches:
               only:


### PR DESCRIPTION
Return the production deploy to 11am by accounting for the end of daylight savings time.